### PR TITLE
Fix-up voice chat for unity 5

### DIFF
--- a/VoiceChat/Assets/VoiceChat/Scene/Demo.unity
+++ b/VoiceChat/Assets/VoiceChat/Scene/Demo.unity
@@ -1,68 +1,81 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-Scene:
+SceneSettings:
   m_ObjectHideFlags: 0
   m_PVSData: 
-  m_QueryMode: 1
   m_PVSObjectsArray: []
   m_PVSPortalsArray: []
   m_OcclusionBakeSettings:
-    viewCellSize: 1
-    bakeMode: 2
-    memoryUsage: 10485760
+    smallestOccluder: 5
+    smallestHole: .25
+    backfaceThreshold: 100
 --- !u!104 &2
 RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
   m_Fog: 0
   m_FogColor: {r: .5, g: .5, b: .5, a: 1}
   m_FogMode: 3
   m_FogDensity: .00999999978
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
-  m_AmbientLight: {r: .200000003, g: .200000003, b: .200000003, a: 1}
+  m_AmbientSkyColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
+  m_AmbientEquatorColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
+  m_AmbientGroundColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
   m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: .5
   m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
   m_HaloTexture: {fileID: 0}
-  m_SpotCookie: {fileID: 0}
-  m_ObjectHideFlags: 0
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
 --- !u!127 &3
-GameManager:
+LevelGameManager:
   m_ObjectHideFlags: 0
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  m_LightProbes: {fileID: 0}
-  m_Lightmaps: []
+  serializedVersion: 5
+  m_GIWorkflowMode: 1
   m_LightmapsMode: 1
-  m_BakedColorSpace: 0
-  m_UseDualLightmapsInForward: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    m_Resolution: 50
-    m_LastUsedResolution: 0
+    serializedVersion: 3
+    m_Resolution: 1
+    m_BakeResolution: 50
     m_TextureWidth: 1024
     m_TextureHeight: 1024
-    m_BounceBoost: 1
-    m_BounceIntensity: 1
-    m_SkyLightColor: {r: .860000014, g: .930000007, b: 1, a: 1}
-    m_SkyLightIntensity: 0
-    m_Quality: 0
-    m_Bounces: 1
-    m_FinalGatherRays: 1000
-    m_FinalGatherContrastThreshold: .0500000007
-    m_FinalGatherGradientThreshold: 0
-    m_FinalGatherInterpolationPoints: 15
-    m_AOAmount: 0
-    m_AOMaxDistance: .100000001
-    m_AOContrast: 1
-    m_LODSurfaceMappingDistance: 1
-    m_Padding: 0
+    m_AOMaxDistance: 1
+    m_Padding: 2
+    m_CompAOExponent: 0
+    m_LightmapParameters: {fileID: 0}
     m_TextureCompression: 0
-    m_LockAtlas: 0
+    m_FinalGather: 0
+    m_FinalGatherRayCount: 1024
+  m_LightmapSnapshot: {fileID: 0}
+  m_RuntimeCPUUsage: 25
 --- !u!196 &5
 NavMeshSettings:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
+    serializedVersion: 2
     agentRadius: .5
     agentHeight: 2
     agentSlope: 45
@@ -71,15 +84,15 @@ NavMeshSettings:
     maxJumpAcrossDistance: 0
     accuratePlacement: 0
     minRegionArea: 2
-    widthInaccuracy: 16.666666
-    heightInaccuracy: 10
-  m_NavMesh: {fileID: 0}
+    cellSize: .166666657
+    manualCellSize: 0
+  m_NavMeshData: {fileID: 0}
 --- !u!1 &718837312
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 3
+  serializedVersion: 4
   m_Component:
   - 4: {fileID: 718837313}
   - 20: {fileID: 718837314}
@@ -102,9 +115,9 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 0
 --- !u!20 &718837314
 Camera:
   m_ObjectHideFlags: 0
@@ -132,7 +145,11 @@ Camera:
     m_Bits: 4294967295
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
   m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: .0219999999
 --- !u!81 &718837315
 AudioListener:
   m_ObjectHideFlags: 0
@@ -159,7 +176,7 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 3
+  serializedVersion: 4
   m_Component:
   - 4: {fileID: 1851515845}
   - 114: {fileID: 1851515846}
@@ -181,9 +198,9 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 2
 --- !u!114 &1851515846
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,8 +209,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1851515844}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 696ef78af3e73d8419ac0f937ee9cc8d, type: 1}
+  m_Script: {fileID: 11500000, guid: 696ef78af3e73d8419ac0f937ee9cc8d, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1851515847
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -202,10 +220,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 1851515844}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e509f36c41097448aff28502e62af7f, type: 1}
+  m_Script: {fileID: 11500000, guid: 4e509f36c41097448aff28502e62af7f, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
   Port: 15000
-  Address: 192.168.0.10
+  Address: 127.0.0.1
 --- !u!114 &1851515848
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,8 +233,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1851515844}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f333559d9aac6e04c831ccd0d1f1c0ff, type: 1}
+  m_Script: {fileID: 11500000, guid: f333559d9aac6e04c831ccd0d1f1c0ff, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
   Port: 15000
   MaxConnections: 8
 --- !u!1 &1913056339
@@ -223,7 +243,7 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 3
+  serializedVersion: 4
   m_Component:
   - 4: {fileID: 1913056340}
   - 114: {fileID: 1913056341}
@@ -244,9 +264,9 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 1
 --- !u!114 &1913056341
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,8 +275,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1913056339}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 17547167380002040b8e43f2e4bc2a42, type: 1}
+  m_Script: {fileID: 11500000, guid: 17547167380002040b8e43f2e4bc2a42, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
   toggleToTalkKey: 111
   pushToTalkKey: 112
   autoDetectSpeaking: 0
@@ -270,8 +291,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1913056339}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: de0860d9b7ab1d142a488b0f614caad1, type: 1}
+  m_Script: {fileID: 11500000, guid: de0860d9b7ab1d142a488b0f614caad1, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
   frequency: 16000
   sampleSize: 640
   compression: 2

--- a/VoiceChat/Assets/VoiceChat/Scripts/Network/Resources/VoiceChat_Player.prefab
+++ b/VoiceChat/Assets/VoiceChat/Scripts/Network/Resources/VoiceChat_Player.prefab
@@ -5,7 +5,7 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 3
+  serializedVersion: 4
   m_Component:
   - 4: {fileID: 400000}
   - 82: {fileID: 8200000}
@@ -16,7 +16,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &400000
 Transform:
   m_ObjectHideFlags: 1
@@ -26,9 +26,9 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
+  m_RootOrder: 0
 --- !u!82 &8200000
 AudioSource:
   m_ObjectHideFlags: 1
@@ -36,12 +36,13 @@ AudioSource:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 100000}
   m_Enabled: 1
-  serializedVersion: 3
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
-  Loop: 0
+  Loop: 1
   Mute: 0
   Priority: 128
   DopplerLevel: 1
@@ -50,6 +51,8 @@ AudioSource:
   Pan2D: 0
   rolloffMode: 0
   BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
   rolloffCustomCurve:
     serializedVersion: 2
     m_Curve:
@@ -85,6 +88,16 @@ AudioSource:
       tangentMode: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -93,8 +106,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 100000}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59b1242259e779d4cb4fc25b48201e51, type: 1}
+  m_Script: {fileID: 11500000, guid: 59b1242259e779d4cb4fc25b48201e51, type: 3}
   m_Name: 
+  m_EditorClassIdentifier: 
   playbackDelay: 2
 --- !u!1001 &100100000
 Prefab:
@@ -107,4 +121,3 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 100000}
   m_IsPrefabParent: 1
-  m_IsExploded: 1

--- a/VoiceChat/Assets/VoiceChat/Scripts/Network/VoiceChatNetworkProxy.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/Network/VoiceChatNetworkProxy.cs
@@ -11,7 +11,7 @@ public class VoiceChatNetworkProxy : MonoBehaviour
 
     void Start()
     {
-        if (networkView.isMine)
+        if (GetComponent<NetworkView>().isMine)
         {
             VoiceChatRecorder.Instance.NewSample += new System.Action<VoiceChatPacket>(OnNewSample);
         }
@@ -19,10 +19,10 @@ public class VoiceChatNetworkProxy : MonoBehaviour
         if (Network.isServer)
         {
             assignedNetworkId = ++networkIdCounter;
-            networkView.RPC("SetNetworkId", networkView.owner, assignedNetworkId);
+            GetComponent<NetworkView>().RPC("SetNetworkId", GetComponent<NetworkView>().owner, assignedNetworkId);
         }
 
-        if(Network.isClient && !networkView.isMine)
+        if(Network.isClient && (!GetComponent<NetworkView>().isMine || VoiceChatSettings.Instance.LocalDebug))
         {
             gameObject.AddComponent<AudioSource>();
             player = gameObject.AddComponent<VoiceChatPlayer>();

--- a/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPlayer.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPlayer.cs
@@ -26,8 +26,8 @@ public class VoiceChatPlayer : MonoBehaviour
     {
         int size = VoiceChatSettings.Instance.Frequency * 10;
 
-        audio.loop = true;
-        audio.clip = AudioClip.Create("VoiceChat", size, 1, VoiceChatSettings.Instance.Frequency, false, false);
+        GetComponent<AudioSource>().loop = true;
+        GetComponent<AudioSource>().clip = AudioClip.Create("VoiceChat", size, 1, VoiceChatSettings.Instance.Frequency, false);
         data = new float[size];
 
         if (VoiceChatSettings.Instance.LocalDebug)
@@ -38,18 +38,18 @@ public class VoiceChatPlayer : MonoBehaviour
 
     void Update()
     {
-        if (audio.isPlaying)
+        if (GetComponent<AudioSource>().isPlaying)
         {
             // Wrapped around
-            if (lastTime > audio.time)
+            if (lastTime > GetComponent<AudioSource>().time)
             {
-                played += audio.clip.length;
+                played += GetComponent<AudioSource>().clip.length;
             }
 
-            lastTime = audio.time;
+            lastTime = GetComponent<AudioSource>().time;
 
             // Check if we've played to far
-            if (played + audio.time >= received)
+            if (played + GetComponent<AudioSource>().time >= received)
             {
                 Stop();
                 shouldPlay = false;
@@ -63,7 +63,7 @@ public class VoiceChatPlayer : MonoBehaviour
 
                 if (playDelay <= 0)
                 {
-                    audio.Play();
+                    GetComponent<AudioSource>().Play();
                 }
             }
         }
@@ -71,8 +71,8 @@ public class VoiceChatPlayer : MonoBehaviour
 
     void Stop()
     {
-        audio.Stop();
-        audio.time = 0;
+        GetComponent<AudioSource>().Stop();
+        GetComponent<AudioSource>().time = 0;
         index = 0;
         played = 0;
         received = 0;
@@ -100,16 +100,16 @@ public class VoiceChatPlayer : MonoBehaviour
         index += length;
 
         // Handle wrap-around
-        if (index >= audio.clip.samples)
+        if (index >= GetComponent<AudioSource>().clip.samples)
         {
             index = 0;
         }
 
         // Set data
-        audio.clip.SetData(data, 0);
+        GetComponent<AudioSource>().clip.SetData(data, 0);
 
         // If we're not playing
-        if (!audio.isPlaying)
+        if (!GetComponent<AudioSource>().isPlaying)
         {
             // Set that we should be playing
             shouldPlay = true;


### PR DESCRIPTION
Fixed up the voice chat library for unity 5. Changed audio to
GetComponent<AudioSource>() in several locations, added logic to allow
Local debug to work with a single client connected to a server. It is
unclear what the intended functionality of Local debug was at this
point since it is useless if you don’t have a server connected. I also changed
the default server address to 127.0.0.1 so the demo will work out of box.