### PR TITLE
Bug fixes and improvements for VoiceChat UNet. 

### DIFF
--- a/VoiceChat/Assets/VoiceChat/Assemblies/Ionic.Zlib.dll.meta
+++ b/VoiceChat/Assets/VoiceChat/Assemblies/Ionic.Zlib.dll.meta
@@ -1,6 +1,18 @@
 fileFormatVersion: 2
 guid: a2579e6f8d2a4ea4bb88ecd18f764e8d
-MonoAssemblyImporter:
+PluginImporter:
   serializedVersion: 1
   iconMap: {}
   executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 1
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VoiceChat/Assets/VoiceChat/Assemblies/NSpeex.dll.meta
+++ b/VoiceChat/Assets/VoiceChat/Assemblies/NSpeex.dll.meta
@@ -1,6 +1,18 @@
 fileFormatVersion: 2
 guid: 32df3f82eaaeca342bc722285d2289f8
-MonoAssemblyImporter:
+PluginImporter:
   serializedVersion: 1
   iconMap: {}
   executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 1
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VoiceChat/Assets/VoiceChat/Resources/VoiceChat_Player.prefab
+++ b/VoiceChat/Assets/VoiceChat/Resources/VoiceChat_Player.prefab
@@ -109,14 +109,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59b1242259e779d4cb4fc25b48201e51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playbackDelay: 2
+  playbackDelay: .100000001
+  packetBufferSize: 5
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
-    m_Modifications: []
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: playbackDelay
+      value: .100000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: packetBufferSize
+      value: 5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 100000}

--- a/VoiceChat/Assets/VoiceChat/Scripts/Demo/HLAPI/VoiceChatNetworkManager.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/Demo/HLAPI/VoiceChatNetworkManager.cs
@@ -10,14 +10,14 @@ namespace VoiceChat.Demo.HLAPI
     {
         public override void OnStartClient(NetworkClient client)
         {
-            VoiceChatNetworkProxy.OnStartClient(client);
+            VoiceChatNetworkProxy.OnManagerStartClient(client);
 
             gameObject.AddComponent<VoiceChatUi>();
         }
 
         public override void OnStopClient()
         {
-            VoiceChatNetworkProxy.OnStopClient();
+            VoiceChatNetworkProxy.OnManagerStopClient();
 
             if (client != null)
                 Destroy(GetComponent<VoiceChatUi>());
@@ -27,19 +27,19 @@ namespace VoiceChat.Demo.HLAPI
         {
             base.OnServerDisconnect(conn);
 
-            VoiceChatNetworkProxy.OnServerDisconnect(conn);
+            VoiceChatNetworkProxy.OnManagerServerDisconnect(conn);
         }
 
         public override void OnStartServer()
         {
-            VoiceChatNetworkProxy.OnStartServer();
+            VoiceChatNetworkProxy.OnManagerStartServer();
 
             gameObject.AddComponent<VoiceChatServerUi>();
         }
 
         public override void OnStopServer()
         {
-            VoiceChatNetworkProxy.OnStopServer();
+            VoiceChatNetworkProxy.OnManagerStopServer();
 
             Destroy(GetComponent<VoiceChatServerUi>());
         }
@@ -47,7 +47,7 @@ namespace VoiceChat.Demo.HLAPI
         public override void OnClientConnect(NetworkConnection connection)
         {
             base.OnClientConnect(connection);
-            VoiceChatNetworkProxy.OnClientConnect(connection);
+            VoiceChatNetworkProxy.OnManagerClientConnect(connection);
         }
     }
 }

--- a/VoiceChat/Assets/VoiceChat/Scripts/Demo/LegacyNetworking.meta
+++ b/VoiceChat/Assets/VoiceChat/Scripts/Demo/LegacyNetworking.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 1b47d4900c5f43b4488844dc2990dbe0
 folderAsset: yes
-timeCreated: 1435263042
+timeCreated: 1435587712
 licenseType: Free
 DefaultImporter:
   userData: 

--- a/VoiceChat/Assets/VoiceChat/Scripts/Networking/VoiceChatPacketMessage.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/Networking/VoiceChatPacketMessage.cs
@@ -11,6 +11,7 @@ namespace VoiceChat.Networking
         public override void Serialize(NetworkWriter writer)
         {
             writer.Write(proxyId);
+            writer.Write(packet.PacketId);
             writer.Write((short)packet.Compression);
             writer.Write(packet.Length);
             writer.WriteBytesFull(packet.Data);
@@ -19,6 +20,7 @@ namespace VoiceChat.Networking
         public override void Deserialize(NetworkReader reader)
         {
             proxyId = reader.ReadInt16();
+            packet.PacketId = reader.ReadUInt64();
             packet.Compression = (VoiceChatCompression)reader.ReadInt16();
             packet.Length = reader.ReadInt32();
             packet.Data = reader.ReadBytesAndSize();

--- a/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPacket.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPacket.cs
@@ -9,6 +9,7 @@ namespace VoiceChat
         public int Length;
         public byte[] Data;
         public int NetworkId;
+        public ulong PacketId;
     }
 
 }

--- a/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPlayer.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatPlayer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace VoiceChat
@@ -6,6 +8,8 @@ namespace VoiceChat
     [RequireComponent(typeof(AudioSource))]
     public class VoiceChatPlayer : MonoBehaviour
     {
+        public event Action PlayerStarted;
+
         float lastTime = 0;
         double played = 0;
         double received = 0;
@@ -17,7 +21,14 @@ namespace VoiceChat
         NSpeex.SpeexDecoder speexDec = new NSpeex.SpeexDecoder(NSpeex.BandMode.Narrow);
 
         [SerializeField]
-        int playbackDelay = 2;
+        [Range(.1f, 5f)]
+        float playbackDelay = .5f;
+
+        [SerializeField]
+        [Range(1, 32)]
+        int packetBufferSize = 10;
+
+        SortedList<ulong, VoiceChatPacket> packetsToPlay = new SortedList<ulong, VoiceChatPacket>();
 
         public float LastRecvTime
         {
@@ -35,6 +46,11 @@ namespace VoiceChat
             if (VoiceChatSettings.Instance.LocalDebug)
             {
                 VoiceChatRecorder.Instance.NewSample += OnNewSample;
+            }
+
+            if(PlayerStarted != null)
+            {
+                PlayerStarted();
             }
         }
 
@@ -81,12 +97,21 @@ namespace VoiceChat
             lastTime = 0;
         }
 
-        public void OnNewSample(VoiceChatPacket packet)
+        public void OnNewSample(VoiceChatPacket newPacket)
         {
-            // Store last packet
-
             // Set last time we got something
             lastRecvTime = Time.time;
+            
+            packetsToPlay.Add(newPacket.PacketId, newPacket);
+
+            if (packetsToPlay.Count < 10)
+            {
+                return;
+            }
+
+            var pair = packetsToPlay.First();
+            var packet = pair.Value;
+            packetsToPlay.Remove(pair.Key);
 
             // Decompress
             float[] sample = null;
@@ -109,7 +134,7 @@ namespace VoiceChat
 
             // Set data
             GetComponent<AudioSource>().clip.SetData(data, 0);
-
+            
             // If we're not playing
             if (!GetComponent<AudioSource>().isPlaying)
             {

--- a/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatRecorder.cs
+++ b/VoiceChat/Assets/VoiceChat/Scripts/VoiceChatRecorder.cs
@@ -7,7 +7,6 @@ namespace VoiceChat
     public class VoiceChatRecorder : MonoBehaviour
     {
         #region Instance
-
         static VoiceChatRecorder instance;
 
         public static VoiceChatRecorder Instance
@@ -23,8 +22,12 @@ namespace VoiceChat
             }
         }
 
+        public AudioClip audioClip { get { return clip; } }
+
         #endregion
 
+        public event Action StartedRecording;
+            
         [SerializeField]
         KeyCode toggleToTalkKey = KeyCode.O;
 
@@ -40,6 +43,7 @@ namespace VoiceChat
         [SerializeField]
         float forceTransmitTime = 2f;
 
+        ulong packetId;
         int previousPosition = 0;
         int sampleIndex = 0;
         string device = null;
@@ -149,12 +153,18 @@ namespace VoiceChat
 
         void OnDisable()
         {
-            instance = null;
+            if (instance == this)
+            {
+                instance = null;
+            }
         }
 
         void OnDestroy()
         {
-            instance = null;
+            if (instance == this)
+            {
+                instance = null;
+            }
         }
 
         void Update()
@@ -295,7 +305,7 @@ namespace VoiceChat
 
             // Set networkid of packet
             packet.NetworkId = NetworkId;
-
+            packet.PacketId = ++packetId;
             // Raise event
             NewSample(packet);
         }
@@ -329,6 +339,11 @@ namespace VoiceChat
             fftBuffer = new float[VoiceChatUtils.ClosestPowerOfTwo(targetSampleSize)];
             recording = true;
 
+            if (StartedRecording != null)
+            {
+                StartedRecording();
+            }
+
             return recording;
         }
 
@@ -336,6 +351,20 @@ namespace VoiceChat
         {
             clip = null;
             recording = false;
+        }
+
+        public void ToggleTransmit()
+        {
+            transmitToggled = !transmitToggled;
+        }
+
+        public void StartTransmit()
+        {
+            transmitToggled = true;
+        }
+        public void StopTransmit()
+        {
+            transmitToggled = false;
         }
     }
 }

--- a/VoiceChat/ProjectSettings/ProjectSettings.asset
+++ b/VoiceChat/ProjectSettings/ProjectSettings.asset
@@ -92,6 +92,9 @@ PlayerSettings:
   APKExpansionFiles: 0
   preloadShaders: 0
   StripUnusedMeshComponents: 0
+  VertexChannelCompressionMask:
+    serializedVersion: 2
+    m_Bits: 238
   iPhoneSdkVersion: 988
   iPhoneTargetOSVersion: 22
   uIPrerenderedIcon: 0
@@ -193,6 +196,8 @@ PlayerSettings:
   ps4SaveDataImagePath: 
   ps4BGMPath: 
   ps4ShareFilePath: 
+  ps4ShareOverlayImagePath: 
+  ps4PrivacyGuardImagePath: 
   ps4NPtitleDatPath: 
   ps4RemotePlayKeyAssignment: -1
   ps4EnterButtonAssignment: 1
@@ -372,20 +377,24 @@ PlayerSettings:
   XboxOnePersistentLocalStorageSize: 0
   intPropertyNames:
   - Metro::ScriptingBackend
+  - Standalone::ScriptingBackend
   - WP8::ScriptingBackend
   - WebGL::ScriptingBackend
   - WebGL::audioCompressionFormat
   - WebGL::exceptionSupport
   - WebGL::memorySize
   - iOS::Architecture
+  - iOS::EnableIncrementalBuildSupportForIl2cpp
   - iOS::ScriptingBackend
   Metro::ScriptingBackend: 2
+  Standalone::ScriptingBackend: 0
   WP8::ScriptingBackend: 2
   WebGL::ScriptingBackend: 1
   WebGL::audioCompressionFormat: 4
   WebGL::exceptionSupport: 1
   WebGL::memorySize: 256
   iOS::Architecture: 2
+  iOS::EnableIncrementalBuildSupportForIl2cpp: 0
   iOS::ScriptingBackend: 1
   boolPropertyNames:
   - WebGL::analyzeBuildSize
@@ -397,8 +406,10 @@ PlayerSettings:
   stringPropertyNames:
   - WebGL::emscriptenArgs
   - WebGL::template
+  - additionalIl2CppArgs::additionalIl2CppArgs
   WebGL::emscriptenArgs: 
   WebGL::template: APPLICATION:Default
+  additionalIl2CppArgs::additionalIl2CppArgs: 
   firstStreamedSceneWithResources: 0
   cloudProjectId: 
   projectId: 

--- a/VoiceChat/ProjectSettings/ProjectVersion.txt
+++ b/VoiceChat/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.1.1f1
+m_EditorVersion: 5.1.3f1
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
List of changes:

Refactored VoiceChatProxy method names (Added "Manager" to the methods that should be called in the custom network manager);
Added packetId field to VoiceChatPacketMessage;
VoiceChatPlayer now buffers and sort 10 packets before it starts the playback;
Fixed ChatRecorder instancing singleton bug;
Added methods StartTransmit, StopTransmit and ToggleTransmit to VoiceChatRecorder;
VoiceChatRecorder now assigns a sequential id to each packet generated;
Added ProxyStarted to VoiceChatNetworkProxy;
ProjectVersion updated from 5.1.1 to 5.1.3
